### PR TITLE
fix: change 新しいタスク from hardcoded text to placeholder

### DIFF
--- a/script.js
+++ b/script.js
@@ -69,7 +69,7 @@ function addCard(listId) {
     
     const cardHtml = `
         <div class="card" draggable="true" ondragstart="drag(event)" id="${newCardId}">
-            <div class="card-content" contenteditable="true">新しいタスク</div>
+            <div class="card-content" contenteditable="true" data-placeholder="新しいタスク"></div>
             <button class="delete-card-btn" onclick="deleteCard('${newCardId}')">×</button>
         </div>
     `;
@@ -78,11 +78,10 @@ function addCard(listId) {
     const cardsContainer = list.querySelector('.cards-container');
     cardsContainer.insertAdjacentHTML('beforeend', cardHtml);
     
-    // 新しく追加されたカードのテキストを選択状態にする
+    // 新しく追加されたカードにフォーカスを当てる
     const newCard = document.getElementById(newCardId);
     const cardContent = newCard.querySelector('.card-content');
     cardContent.focus();
-    cardContent.select();
     
     saveToLocalStorage();
 }

--- a/style.css
+++ b/style.css
@@ -215,6 +215,12 @@ body {
     background-color: rgba(0, 0, 0, 0.05);
 }
 
+.card-content[data-placeholder]:empty::before {
+    content: attr(data-placeholder);
+    color: #999;
+    opacity: 0.7;
+}
+
 .delete-card-btn {
     position: absolute;
     top: 0.25rem;


### PR DESCRIPTION
Issue #4に対応し、カード追加時の「新しいタスク」をプレースホルダーに変更しました。

✅ 「新しいタスク」をプレースホルダーに変更
✅ 「新しいリスト」と「新しいボード」は文字列のまま維持

Generated with [Claude Code](https://claude.ai/code)