### PR TITLE
fix: 日本語入力時の文字重複バグを修正

### DIFF
--- a/script.js
+++ b/script.js
@@ -257,9 +257,27 @@ function getDragAfterElement(container, y) {
 // 編集可能要素のイベントハンドリング
 document.addEventListener('click', function(event) {
     if (event.target.contentEditable === 'true') {
+        let isComposing = false;
+        
+        // IME composition events
+        event.target.addEventListener('compositionstart', function() {
+            isComposing = true;
+        });
+        
+        event.target.addEventListener('compositionend', function() {
+            isComposing = false;
+            saveToLocalStorage();
+        });
+        
+        event.target.addEventListener('input', function() {
+            if (!isComposing) {
+                saveToLocalStorage();
+            }
+        });
+        
         event.target.addEventListener('blur', saveToLocalStorage);
         event.target.addEventListener('keydown', function(e) {
-            if (e.key === 'Enter') {
+            if (e.key === 'Enter' && !isComposing) {
                 e.target.blur();
             }
         });


### PR DESCRIPTION
Issue #6 の日本語入力重複バグを修正しました。

IME composition イベントを適切に処理することで、日本語入力時に変換確定で文字が重複する問題を解決しました。

Generated with [Claude Code](https://claude.ai/code)