### PR TITLE
fix: カードドラッグ終了時に必ず回転状態をリセット

### DIFF
--- a/script.js
+++ b/script.js
@@ -48,6 +48,11 @@ function attachEventListeners() {
         card.addEventListener('dragstart', function(e) {
             drag(e);
         });
+        // ドラッグ終了時のイベントリスナーも設定
+        card.addEventListener('dragend', function(e) {
+            e.target.classList.remove('dragging');
+            draggedElement = null;
+        });
     });
     
     // すべてのカードコンテナにドロップイベントを設定
@@ -195,6 +200,12 @@ function drag(event) {
     event.target.classList.add('dragging');
     event.dataTransfer.effectAllowed = 'move';
     event.dataTransfer.setData('text/html', event.target.outerHTML);
+    
+    // ドラッグ終了時に必ずdraggingクラスを削除するイベントリスナーを追加
+    event.target.addEventListener('dragend', function() {
+        event.target.classList.remove('dragging');
+        draggedElement = null;
+    }, { once: true });
 }
 
 // ドラッグ許可


### PR DESCRIPTION
Issue #7 の修正: カードをドラッグして、配置できない場所にドロップすると、カードが元の状態に戻らず、斜めの状態のままになる問題を修正しました。

## 変更内容
- dragendイベントリスナーを追加してdraggingクラスを確実に削除
- 無効な場所へのドロップ後もカードが元の状態に戻るように改善
- attachEventListenersでも同様の処理を追加
- close #7
Generated with [Claude Code](https://claude.ai/code)