### PR TITLE
feat: 設定画面とデータクリア機能を実装

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,10 @@
 <body>
     <header class="header">
         <h1 class="app-title">Trello風タスク管理アプリ</h1>
-        <button class="add-board-btn" id="addBoardBtn">新しいボードを追加</button>
+        <div class="header-buttons">
+            <button class="add-board-btn" id="addBoardBtn">新しいボードを追加</button>
+            <button class="settings-btn" id="settingsBtn">⚙️ 設定</button>
+        </div>
     </header>
 
     <main class="main-content">
@@ -74,6 +77,39 @@
             </div>
         </div>
     </main>
+
+    <!-- 設定ダイアログ -->
+    <div class="modal-overlay" id="settingsModal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3>設定</h3>
+                <button class="modal-close-btn" id="closeSettingsBtn">×</button>
+            </div>
+            <div class="modal-body">
+                <div class="setting-section">
+                    <h4>データ管理</h4>
+                    <p>全てのボード、リスト、カードを初期状態に戻します。</p>
+                    <button class="data-clear-btn" id="dataClearBtn">データをクリア</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- 確認ダイアログ -->
+    <div class="modal-overlay" id="confirmModal">
+        <div class="modal-content confirm-modal">
+            <div class="modal-header">
+                <h3>確認</h3>
+            </div>
+            <div class="modal-body">
+                <p id="confirmMessage">この操作を実行しますか？</p>
+                <div class="confirm-buttons">
+                    <button class="cancel-btn" id="cancelBtn">キャンセル</button>
+                    <button class="confirm-btn" id="confirmBtn">OK</button>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -10,6 +10,30 @@ document.addEventListener('DOMContentLoaded', function() {
     // ボード追加ボタンのイベントリスナー
     document.getElementById('addBoardBtn').addEventListener('click', addBoard);
     
+    // 設定ボタンのイベントリスナー
+    document.getElementById('settingsBtn').addEventListener('click', openSettingsModal);
+    
+    // 設定ダイアログのイベントリスナー
+    document.getElementById('closeSettingsBtn').addEventListener('click', closeSettingsModal);
+    document.getElementById('dataClearBtn').addEventListener('click', showDataClearConfirm);
+    
+    // 確認ダイアログのイベントリスナー
+    document.getElementById('cancelBtn').addEventListener('click', closeConfirmModal);
+    document.getElementById('confirmBtn').addEventListener('click', handleConfirmAction);
+    
+    // モーダルオーバーレイクリックで閉じる
+    document.getElementById('settingsModal').addEventListener('click', function(e) {
+        if (e.target === this) {
+            closeSettingsModal();
+        }
+    });
+    
+    document.getElementById('confirmModal').addEventListener('click', function(e) {
+        if (e.target === this) {
+            closeConfirmModal();
+        }
+    });
+    
     // 初期化時にローカルストレージからデータを読み込み
     loadFromLocalStorage();
     
@@ -552,4 +576,136 @@ function getListDragAfterElement(container, x) {
             return closest;
         }
     }, { offset: Number.NEGATIVE_INFINITY }).element;
+}
+
+// 設定モーダル関連の機能
+let currentConfirmAction = null;
+
+// 設定ダイアログを開く
+function openSettingsModal() {
+    document.getElementById('settingsModal').classList.add('show');
+}
+
+// 設定ダイアログを閉じる
+function closeSettingsModal() {
+    document.getElementById('settingsModal').classList.remove('show');
+}
+
+// 確認ダイアログを開く
+function openConfirmModal(message, action) {
+    document.getElementById('confirmMessage').textContent = message;
+    currentConfirmAction = action;
+    document.getElementById('confirmModal').classList.add('show');
+}
+
+// 確認ダイアログを閉じる
+function closeConfirmModal() {
+    document.getElementById('confirmModal').classList.remove('show');
+    currentConfirmAction = null;
+}
+
+// データクリア確認を表示
+function showDataClearConfirm() {
+    openConfirmModal(
+        '全てのデータを削除して初期状態に戻します。この操作は元に戻せません。続行しますか？',
+        'clearData'
+    );
+}
+
+// 確認アクションを処理
+function handleConfirmAction() {
+    if (currentConfirmAction === 'clearData') {
+        clearAllData();
+    }
+    closeConfirmModal();
+}
+
+// 全データをクリアして初期状態に戻す
+function clearAllData() {
+    // LocalStorageをクリア
+    localStorage.removeItem('trelloApp');
+    localStorage.removeItem('cardCounter');
+    localStorage.removeItem('listCounter');
+    localStorage.removeItem('boardCounter');
+    
+    // カウンターをリセット
+    cardCounter = 2;
+    listCounter = 3;
+    boardCounter = 1;
+    
+    // デフォルトのHTML構造を設定
+    const defaultHtml = `
+        <div class="board" id="board-1">
+            <div class="board-header">
+                <h2 class="board-title" contenteditable="true">マイボード</h2>
+                <button class="delete-board-btn" onclick="deleteBoard('board-1')">×</button>
+            </div>
+            <div class="lists-container" ondrop="dropList(event)" ondragover="allowDropList(event)">
+                <!-- To Do リスト -->
+                <div class="list" id="list-1" data-board="board-1" draggable="true" ondragstart="dragList(event)" ondragend="endDragList(event)">
+                    <div class="list-header">
+                        <div class="list-drag-handle">⋮⋮</div>
+                        <h3 class="list-title" contenteditable="true">To Do</h3>
+                        <button class="delete-list-btn" onclick="deleteList('list-1')">×</button>
+                    </div>
+                    <div class="cards-container" ondrop="drop(event)" ondragover="allowDrop(event)">
+                        <!-- サンプルカード -->
+                        <div class="card" draggable="true" ondragstart="drag(event)" id="card-1">
+                            <div class="card-content" contenteditable="true">サンプルタスク1</div>
+                            <button class="delete-card-btn" onclick="deleteCard('card-1')">×</button>
+                        </div>
+                    </div>
+                    <button class="add-card-btn" onclick="addCard('list-1')">+ カードを追加</button>
+                </div>
+
+                <!-- In Progress リスト -->
+                <div class="list" id="list-2" data-board="board-1" draggable="true" ondragstart="dragList(event)" ondragend="endDragList(event)">
+                    <div class="list-header">
+                        <div class="list-drag-handle">⋮⋮</div>
+                        <h3 class="list-title" contenteditable="true">In Progress</h3>
+                        <button class="delete-list-btn" onclick="deleteList('list-2')">×</button>
+                    </div>
+                    <div class="cards-container" ondrop="drop(event)" ondragover="allowDrop(event)">
+                        <div class="card" draggable="true" ondragstart="drag(event)" id="card-2">
+                            <div class="card-content" contenteditable="true">サンプルタスク2</div>
+                            <button class="delete-card-btn" onclick="deleteCard('card-2')">×</button>
+                        </div>
+                    </div>
+                    <button class="add-card-btn" onclick="addCard('list-2')">+ カードを追加</button>
+                </div>
+
+                <!-- Done リスト -->
+                <div class="list" id="list-3" data-board="board-1" draggable="true" ondragstart="dragList(event)" ondragend="endDragList(event)">
+                    <div class="list-header">
+                        <div class="list-drag-handle">⋮⋮</div>
+                        <h3 class="list-title" contenteditable="true">Done</h3>
+                        <button class="delete-list-btn" onclick="deleteList('list-3')">×</button>
+                    </div>
+                    <div class="cards-container" ondrop="drop(event)" ondragover="allowDrop(event)">
+                    </div>
+                    <button class="add-card-btn" onclick="addCard('list-3')">+ カードを追加</button>
+                </div>
+
+                <!-- 新しいリストを追加ボタン -->
+                <div class="add-list-container">
+                    <button class="add-list-btn" onclick="addList('board-1')">+ リストを追加</button>
+                </div>
+            </div>
+        </div>
+    `;
+    
+    // ボードコンテナに初期状態を設定
+    document.getElementById('boardContainer').innerHTML = defaultHtml;
+    
+    // イベントリスナーを再設定
+    attachEventListeners();
+    
+    // LocalStorageに保存
+    saveToLocalStorage();
+    
+    // 設定ダイアログを閉じる
+    closeSettingsModal();
+    
+    // 成功メッセージを表示
+    alert('データがクリアされ、初期状態に戻りました。');
 }

--- a/style.css
+++ b/style.css
@@ -31,7 +31,13 @@ body {
     font-weight: bold;
 }
 
-.add-board-btn {
+.header-buttons {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.add-board-btn, .settings-btn {
     background-color: rgba(255, 255, 255, 0.2);
     color: white;
     border: none;
@@ -42,7 +48,7 @@ body {
     transition: background-color 0.3s ease;
 }
 
-.add-board-btn:hover {
+.add-board-btn:hover, .settings-btn:hover {
     background-color: rgba(255, 255, 255, 0.3);
 }
 
@@ -378,4 +384,138 @@ body {
     .card {
         padding: 0.5rem;
     }
+}
+
+/* モーダルスタイル */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: none;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+}
+
+.modal-overlay.show {
+    display: flex;
+}
+
+.modal-content {
+    background-color: white;
+    border-radius: 8px;
+    max-width: 500px;
+    width: 90%;
+    max-height: 80%;
+    overflow-y: auto;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.5rem;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.modal-header h3 {
+    margin: 0;
+    color: #333;
+    font-size: 1.2rem;
+}
+
+.modal-close-btn {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+    color: #666;
+    width: 30px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    transition: background-color 0.3s ease;
+}
+
+.modal-close-btn:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+.modal-body {
+    padding: 1.5rem;
+}
+
+.setting-section {
+    margin-bottom: 1.5rem;
+}
+
+.setting-section h4 {
+    color: #333;
+    margin-bottom: 0.5rem;
+}
+
+.setting-section p {
+    color: #666;
+    margin-bottom: 1rem;
+    line-height: 1.5;
+}
+
+.data-clear-btn {
+    background-color: #d32f2f;
+    color: white;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: background-color 0.3s ease;
+}
+
+.data-clear-btn:hover {
+    background-color: #b71c1c;
+}
+
+/* 確認ダイアログ */
+.confirm-modal {
+    max-width: 400px;
+}
+
+.confirm-buttons {
+    display: flex;
+    gap: 1rem;
+    justify-content: flex-end;
+    margin-top: 1.5rem;
+}
+
+.cancel-btn, .confirm-btn {
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: background-color 0.3s ease;
+}
+
+.cancel-btn {
+    background-color: #f5f5f5;
+    color: #333;
+}
+
+.cancel-btn:hover {
+    background-color: #e0e0e0;
+}
+
+.confirm-btn {
+    background-color: #d32f2f;
+    color: white;
+}
+
+.confirm-btn:hover {
+    background-color: #b71c1c;
 }


### PR DESCRIPTION
## 概要

設定画面とデータクリア機能を実装しました。

## 変更内容

- ヘッダーに設定ボタンを追加（「新しいボードを追加」の右側）
- 設定ダイアログをモーダル形式で実装
- データクリアボタンと確認ダイアログを追加
- データクリア時に初期状態（デフォルトのボード、リスト、サンプルタスク）に復元
- 全ての操作が日本語で表示される

Closes #12

Generated with [Claude Code](https://claude.ai/code)